### PR TITLE
bugfixes for stripped files

### DIFF
--- a/ljd/ast/nodes.py
+++ b/ljd/ast/nodes.py
@@ -207,6 +207,7 @@ class Identifier():
 		self.name = None
 		self.type = -1
 		self.slot = -1
+		self._varinfo = None
 
 	def _accept(self, visitor):
 		visitor._visit_node(visitor.visit_identifier, self)

--- a/ljd/rawdump/code.py
+++ b/ljd/rawdump/code.py
@@ -176,7 +176,7 @@ def read(parser):
 
 	if instruction_class is None:
 		errprint("Warning: unknown opcode {0:08x}", opcode)
-		instruction_class = instructions.UNKN  # @UndefinedVariable
+		instruction_class = instructions.UNKNW  # @UndefinedVariable
 
 	instruction = instruction_class()
 

--- a/ljd/rawdump/parser.py
+++ b/ljd/rawdump/parser.py
@@ -62,6 +62,8 @@ def _read_header(parser, header):
 	else:
 		parser.stream.data_byteorder = 'little'
 
+	parser.flags = header.flags
+
 	return True
 
 


### PR DESCRIPTION
- Predefines _varinfo in case of missing debug info (needed for update_locals)
- Copies header flags to parser flags (was missing)
- Fixes typo for unknown bytecodes