### PR TITLE
Fix typo in rawdump/code.py

### DIFF
--- a/ljd/rawdump/code.py
+++ b/ljd/rawdump/code.py
@@ -176,7 +176,7 @@ def read(parser):
 
 	if instruction_class is None:
 		errprint("Warning: unknown opcode {0:08x}", opcode)
-		instruction_class = instructions.UNKN  # @UndefinedVariable
+		instruction_class = instructions.UNKNW  # @UndefinedVariable
 
 	instruction = instruction_class()
 


### PR DESCRIPTION
I noticed unknown instruction is defined as UNKNW, but it was written as UNKN here.